### PR TITLE
fix: Fix double-quote bug + Add more definition handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,11 @@ go run cmd/graphql-schema-picker/main.go \
     --sdl-file examples/hasura.sdl.graphqls \
     --definitions Aircrafts
 ```
+
+## Similar Tools
+
+- https://github.com/n1ru4l/graphql-public-schema-filter
+- https://github.com/kesne/graphql-schema-subset
+- https://github.com/xometry/graphql-code-generator-subset-plugin
+- https://the-guild.dev/graphql/tools/docs/api/classes/wrap_src.pruneschema
+- https://pothos-graphql.dev/docs/plugins/sub-graph

--- a/internal/cli/graph_edges.go
+++ b/internal/cli/graph_edges.go
@@ -1,0 +1,110 @@
+package cli
+
+import (
+	"errors"
+	"github.com/charmbracelet/log"
+	"github.com/dominikbraun/graph"
+	"github.com/graphql-go/graphql/language/ast"
+	"github.com/graphql-go/graphql/language/kinds"
+)
+
+func buildEdges(g graph.Graph[string, Vertex]) {
+	for _, desired := range desiredDefinitions {
+		v, err := g.Vertex(desired)
+		if err != nil {
+			if errors.Is(err, graph.ErrVertexNotFound) {
+				log.Errorf("unable to find definition for: %s", desired)
+			} else {
+				log.Fatal("unable to read vertex", "err", err)
+			}
+		}
+
+		switch v.Node.GetKind() {
+		case kinds.ObjectDefinition:
+			buildEdgesForObject(v, g)
+		case kinds.InterfaceDefinition:
+			buildEdgesForInterface(v, g)
+		case kinds.UnionDefinition:
+			buildEdgesForUnion(v, g)
+		case kinds.InputObjectDefinition:
+			buildEdgesForInputObject(v, g)
+		default:
+			log.Warnf("Ignoring dependencies for %s node", v.Node.GetKind())
+		}
+	}
+}
+
+func buildEdgesFromFieldDefs(
+	g graph.Graph[string, Vertex],
+	name string,
+	fields []*ast.FieldDefinition,
+) {
+	for _, f := range fields {
+		// Is the field a primitive scalar (e.g., Int, String)?
+		// If so, we can skip it, as it's natively a part of any
+		// GraphQL schema.
+		rootType := getRootTypeNameHelper(f.Type, 0)
+		if isBasicType(rootType) {
+			continue
+		}
+
+		log.Debug("Found field in object",
+			"object", name,
+			"name", f.Name.Value,
+			"type", rootType,
+		)
+
+		_ = g.AddEdge(name, rootType)
+
+		// Iterate through f.Argument --
+		// since Fields are also dependencies themselves!
+		args := f.Arguments
+		for _, arg := range args {
+			root := getRootTypeNameHelper(arg.Type, 0)
+			if isBasicType(root) {
+				continue
+			}
+			_ = g.AddEdge(name, root)
+		}
+	}
+}
+
+func buildEdgesForObject(v Vertex, g graph.Graph[string, Vertex]) {
+	obj := v.Node.(*ast.ObjectDefinition)
+	fields := obj.Fields
+	buildEdgesFromFieldDefs(g, obj.Name.Value, fields)
+}
+
+func buildEdgesForInterface(v Vertex, g graph.Graph[string, Vertex]) {
+	obj := v.Node.(*ast.InterfaceDefinition)
+	fields := obj.Fields
+	buildEdgesFromFieldDefs(g, obj.Name.Value, fields)
+}
+
+func buildEdgesForUnion(v Vertex, g graph.Graph[string, Vertex]) {
+	// TODO add support
+}
+
+func buildEdgesForInputObject(v Vertex, g graph.Graph[string, Vertex]) {
+	obj := v.Node.(*ast.InputObjectDefinition)
+	fields := obj.Fields
+	name := obj.Name.Value
+
+	for _, f := range fields {
+		// Is the field a primitive scalar (e.g., Int, String)?
+		// If so, we can skip it, as it's natively a part of any
+		// GraphQL schema.
+		rootType := getRootTypeNameHelper(f.Type, 0)
+		if isBasicType(rootType) {
+			continue
+		}
+
+		log.Debug("Found field in object",
+			"object", name,
+			"name", f.Name.Value,
+			"type", rootType,
+		)
+
+		_ = g.AddEdge(name, rootType)
+	}
+}

--- a/internal/cli/print.go
+++ b/internal/cli/print.go
@@ -9,7 +9,7 @@ import (
 )
 
 func printSDL(doc *ast.Document) {
-	sdl := printer.Print(doc)
+	log.Infof("Printing new SDL to file with %d definitions", len(doc.Definitions))
 
 	// Create a new file where we'll write the new SDL
 	// TODO make configurable
@@ -22,8 +22,18 @@ func printSDL(doc *ast.Document) {
 
 	w := bufio.NewWriter(f)
 
-	_, err = w.WriteString(sdl.(string))
+	sdl := printer.Print(doc)
+
+	sdlString, ok := sdl.(string)
+	if !ok {
+		log.Fatal("expected SDL to be a string")
+	}
+
+	log.Debug(sdlString)
+
+	_, err = w.WriteString(sdlString)
 	if err != nil {
 		log.Fatal("unable to produce new SDL file", "err", err)
 	}
+	defer w.Flush()
 }

--- a/test/schema.graphql
+++ b/test/schema.graphql
@@ -1,8 +1,14 @@
+"""
+Representation of a "Foo"
+"""
 type Foo {
   name: String
   bar: Bar
 }
 
+"""
+Representation of a "Bar
+"""
 type Bar {
   name: String
   quantity: Int!


### PR DESCRIPTION
- Workaround for double-quote comment bug — https://github.com/graphql-go/graphql/issues/677
- Correctly infer dependencies for object, interface, union, and interface object